### PR TITLE
add script to generate tags.txt

### DIFF
--- a/bin/generatetags.sh
+++ b/bin/generatetags.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 cd ../..
-git clone https://github.com/mhwkb/mhwkb.github.io
-cd mhwkb.github.io
+git clone https://github.com/mhwkb/mhwkb.github.io tags_mhwkb_tmp
+cd tags_mhwkb_tmp
 
 echo -e "List of Existing Tags\n" >> tags.txt
 echo -e "If you need suggestions for tags, this is a good list for reference.\n" >> tags.txt

--- a/bin/generatetags.sh
+++ b/bin/generatetags.sh
@@ -4,11 +4,11 @@ cd ../..
 git clone https://github.com/mhwkb/mhwkb.github.io tags_mhwkb_tmp
 cd tags_mhwkb_tmp
 
-echo -e "List of Existing Tags\n" >> tags.txt
-echo -e "If you need suggestions for tags, this is a good list for reference.\n" >> tags.txt
+/bin/echo -e "List of Existing Tags\n" >> tags.txt
+/bin/echo -e "If you need suggestions for tags, this is a good list for reference.\n" >> tags.txt
 
 DATE=`date +%Y-%m-%d`
-echo -e "Last updated $DATE\n" >> tags.txt
+/bin/echo -e "Last updated $DATE\n" >> tags.txt
 
 ls >> tags.txt
 

--- a/bin/generatetags.sh
+++ b/bin/generatetags.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+cd ../..
+git clone https://github.com/mhwkb/mhwkb.github.io
+cd mhwkb.github.io
+
+echo -e "List of Existing Tags\n" >> tags.txt
+echo -e "If you need suggestions for tags, this is a good list for reference.\n" >> tags.txt
+
+DATE=`date +%Y-%m-%d`
+echo -e "Last updated $DATE\n" >> tags.txt
+
+ls >> tags.txt
+
+sed -i 's/.html//g' tags.txt
+
+sed -i '/LICENSE/d' tags.txt
+sed -i '/README.md/d' tags.txt
+sed -i '/mhwkb_style.css/d' tags.txt
+sed -i '/tags.txt/d' tags.txt
+
+exit 0;


### PR DESCRIPTION
Not sure if there is any interest for this but here's a script to generate the `tags.txt` file.

Here's what it does:
1. Assumes you are in mhwkb/bin when executing
2. Changes into parent dir of mhwkb
3. Clones the repo where html files are stored.
4. Changes into that directory.
5. Adds the header with current date into a new `tags.txt` file
6. Prints the dir listing into `tags.txt`
7. Removes all `.html` from `tags.txt`
8. Removes `LICENSE`, `README.md`, `mhwkb_style.css`, and `tags.txt` lines from `tags.txt`

Then all you have to do is to replace `mhwkb/tags.txt` with the new file `mhwkb.github.io/tags.txt`.



